### PR TITLE
Refactor init logic to dataclasses

### DIFF
--- a/ns_pipelines/participant_demographics/run.py
+++ b/ns_pipelines/participant_demographics/run.py
@@ -94,7 +94,7 @@ def ParticipantDemographics(IndependentPipeline):
     """Participant demographics extraction pipeline."""
 
     _version = "1.0.0"
-    _hash_args = ["extraction_model", "prompt_set", "kwargs", "_inputs", "_input_sources"]
+    _hash_attrs = ["extraction_model", "prompt_set", "kwargs", "_inputs", "_input_sources"]
 
     def __init__(
         self,

--- a/ns_pipelines/pipeline.py
+++ b/ns_pipelines/pipeline.py
@@ -64,7 +64,7 @@ class FileManager:
 class Pipeline(ABC):
     """Abstract pipeline class for processing data."""
 
-    _hash_attrs: List[str] = []
+    _hash_attrs: List[str] = ['_inputs', '_input_sources']
     _pipeline_type: str = None  # independent or dependent
     _version: str = None
 

--- a/ns_pipelines/pipeline.py
+++ b/ns_pipelines/pipeline.py
@@ -64,7 +64,7 @@ class FileManager:
 class Pipeline(ABC):
     """Abstract pipeline class for processing data."""
 
-    _hash_args: List[str] = []
+    _hash_attrs: List[str] = []
     _pipeline_type: str = None  # independent or dependent
     _version: str = None
 
@@ -78,7 +78,7 @@ class Pipeline(ABC):
 
     def serialize_pipeline_args(self) -> str:
         """Return a hashable string of the arguments."""
-        return '_'.join([str(getattr(self, arg)) for arg in self._hash_args])
+        return '_'.join([str(getattr(self, arg)) for arg in self._hash_attrs])
 
     def full_output_hash(self, dataset_str: str, arg_str: str) -> str:
         """Return the full hash."""

--- a/ns_pipelines/word_count/run.py
+++ b/ns_pipelines/word_count/run.py
@@ -32,7 +32,7 @@ class WordDevianceExtraction(DependentPipeline):
     _hash_args = ["_inputs", "_input_sources"]
     _pipeline_type = "dependent"
 
-    def group_function(self, all_study_inputs):
+    def function(self, all_study_inputs):
         """Run the word count extraction pipeline."""
 
         # Calculate the average word count

--- a/ns_pipelines/word_count/run.py
+++ b/ns_pipelines/word_count/run.py
@@ -9,7 +9,7 @@ class WordCountExtraction(IndependentPipeline):
     """Word count extraction pipeline."""
 
     _version = "1.0.0"
-    _hash_args = ["_inputs", "_input_sources"]
+    _hash_attrs = ["_inputs", "_input_sources"]
     _pipeline_type = "independent"
 
     def function(self, study_inputs):
@@ -29,7 +29,7 @@ class WordDevianceExtraction(DependentPipeline):
     """
 
     _version = "1.0.0"
-    _hash_args = ["_inputs", "_input_sources"]
+    _hash_attrs = ["_inputs", "_input_sources"]
     _pipeline_type = "dependent"
 
     def function(self, all_study_inputs):


### PR DESCRIPTION
Not done yet but I spent some time (probably too much) looking at this stylistic issue.

Lmk what you think.

I think its cleans up the logic somewhat but the issue is that dataclasses are not a great fit for processing their own attributes, when those are based on information that you don't want to store.

For example, you don't necessarily need to store the source_dir of each `PubgetRaw` as its somewhat redundant information, but you need it to pull out the data for each. So because of that I stopped at pushing more logic down to the dataclasses as that would require passing down more unnecessary information to store.

But I think its OK if a study stores its `study_dir`.